### PR TITLE
Alpha 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ After update please close your terminal and open it again
  5. **help** ~ for get help <br>
  example ~ type ```help``` and hit enter  
  
- 6. **please** ~ added for fun <br>
+ 6. **clean-cache** ~ Clean up all local caches <br>
+ example ~ `clean-cache` and hit enter  
+ 
+ 7. **please** ~ added for fun <br>
  `please` works replace of **sudo** command <br>
  example ~ `please install toilet` and hit enter 
  

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# Common-command-line-interface-CCLI
+# CCLI 
+## Common Command Line Interface
 
 ## Installation
 
-> Note : Before use CCLI please install `git` on your machine.
+> Note 
+ * Before use CCLI please install `git` on your machine.
+ * This is build for `bash` only. But you can add it on `fish` and `zsh` manually.
 
 Copy and paste those commands on your terminal 
 ```
@@ -10,9 +13,13 @@ git clone https://github.com/farhansadik/Common-command-line-interface-CCLI.git
 cd Common-command-line-interface-CCLI
 ./install
 ```
-After install close your terminal and open it again
+After install close your terminal and open it again or enter `source ~/.bashrc` command. 
 
 ## Update CCLI
+> Note 
+ * Before update open your `*rc` file and remove all of alias from `*rc` files....
+ * and then try to update 
+ 
 Copy and paste those commands on your terminal 
 ```
 cd Common-command-line-interface-CCLI
@@ -37,11 +44,19 @@ After update please close your terminal and open it again
  5. **help** ~ for get help <br>
  example ~ type ```help``` and hit enter  
  
+ 6. **please** ~ added for fun <br>
+ `please` works replace of **sudo** command <br>
+ example ~ `please install toilet` and hit enter 
+ 
 ## Support 
  1. Supported Arch Linux and Arch Linux Based Distro
-     * tested on **manjaro** and **antergos**
+     * tested on **manjaro**, **antergos**, **arch**
  2. Supported Debian and Debian Based Distro
      * tested on **ubuntu** and **linux mint**
+     
+## Not Supported 
+ 1. We added **openSUSE** configuration. Not installed it on `install` script. You can install **openSUSE** config manually. 
+ 2. We added **RedHat** and **Feadora** configuration. Not installed it on `install` script. You can install those config manually. 
 
 ## Develpoment
 **Created By,** 

--- a/arch.cfg
+++ b/arch.cfg
@@ -3,10 +3,13 @@
 # build for arch and arch based distro
 
 alias install='sudo pacman -S'
-alias remove='sudo pacman -R'
+alias remove='sudo pacman -Rs'
 alias sync='sudo pacman -Syy'
 alias upgrade='sudo pacman -Syu'
+alias clean-cache='sudo pacman -Scc'
 
+# configuration-settings
 alias ccli-help='less ~/.config/ccli/help.txt'
+alias ccli-settings='not installed'
 
 # created by farhan sadik

--- a/arch.cfg
+++ b/arch.cfg
@@ -7,6 +7,7 @@ alias remove='sudo pacman -Rs'
 alias sync='sudo pacman -Syy'
 alias upgrade='sudo pacman -Syu'
 alias clean-cache='sudo pacman -Scc'
+alias please='sudo'
 
 # configuration-settings
 alias ccli-help='less ~/.config/ccli/help.txt'

--- a/deb.cfg
+++ b/deb.cfg
@@ -6,6 +6,7 @@ alias remove='sudo apt remove'
 alias sync='sudo apt update'
 alias upgrade='sudo apt upgrade'
 alias clean-cache='sudo apt autoclean'
+alias please='sudo'
 
 # configuration-settings
 alias ccli-help='less ~/.config/ccli/help.txt'

--- a/deb.cfg
+++ b/deb.cfg
@@ -5,7 +5,10 @@ alias install='sudo apt install'
 alias remove='sudo apt remove'
 alias sync='sudo apt update'
 alias upgrade='sudo apt upgrade'
+alias clean-cache='sudo apt autoclean'
 
+# configuration-settings
 alias ccli-help='less ~/.config/ccli/help.txt'
+alias ccli-settings='not installed'
 
 # created by farhan sadik

--- a/install
+++ b/install
@@ -2,9 +2,10 @@
 
 set import busybox 
 set import bash from busybox
+set import zsh from busybox
 set import git 
 
-script_version="0.1.09 Alpha";
+script_version="0.1.1 Alpha"; # 0.1.09 Alpha
 
 # define variable 
 red='\033[1;91m'; deep_green='\033[0;32m'; green='\033[1;92m'; yellow='\033[1;93m'; blue='\033[1;94m'; white='\033[1;97m'; stop='\e[0m';
@@ -32,6 +33,7 @@ function FileOperation() {
 	}; fi
 }
 function ArchOperation() {
+	# 
 	if printf "$yellow" && printf "Cloning Configuration : $red"; then {
 		if less $arch_configuration >> $pc_config; then {
 			printf "Done$stop\n";	
@@ -48,15 +50,32 @@ function DebianOperation() {
 function DistroOperation() {
 	printf "$yellow" && printf "Searching for distro  : $red"
 	if lsb_release -i | grep 'Antergos' >> $log; then {
+
+		# Arch - Antergos 
 		printf "Antergos Linux\n"; ArchOperation;
+
 	}; elif lsb_release -i | grep 'LinuxMint' >> $log; then {
+
+		# Debian - Linux Mint 
 		printf "Linux Mint\n"; DebianOperation;
+
 	}; elif lsb_release -i | grep 'ManjaroLinux' >> $log; then {
+
+		# Arch - Manjaro 
 		printf "Manjaro Linux\n"; ArchOperation;
+
 	}; elif lsb_release -i | grep 'Ubuntu' >> $log; then {
+
+		# Debian - Ubuntu
 		printf "Ubuntu\n"; DebianOperation;
+
+	}; elif lsb_release -i | grep 'Arch' >> $log; then {
+
+		# Arch - Arch Linux 
+		printf "Arch Linux\n"; ArchOperation;
+
 	}; else {
-		sleep 0.5; printf "Failed\n";
+		sleep 0.5; printf "Failed to locate distro\n";
 	}; fi; printf "$stop"
 }
 

--- a/redhat.cfg
+++ b/redhat.cfg
@@ -1,0 +1,14 @@
+
+# builded for RedHat and rpm based distros
+
+alias install='dnf install'
+alias remove='dnf remove'
+alias sync='dnf upgrade'
+alias upgrade='dnf distro-sync'
+alias clean-cache='dnf clean all'
+
+# configuration-settings
+alias ccli-help='less ~/.config/ccli/help.txt'
+alias ccli-settings='not installed'
+
+# Created by farhan sadik

--- a/redhat.cfg
+++ b/redhat.cfg
@@ -6,6 +6,7 @@ alias remove='dnf remove'
 alias sync='dnf upgrade'
 alias upgrade='dnf distro-sync'
 alias clean-cache='dnf clean all'
+alias please='sudo'
 
 # configuration-settings
 alias ccli-help='less ~/.config/ccli/help.txt'

--- a/suse.cfg
+++ b/suse.cfg
@@ -1,0 +1,15 @@
+
+# builded for openSUSE and SLES based distros
+
+alias install='sudo zypper install'
+alias remove='sudo zypper remove'
+alias sync='sudo zypper update'
+alias upgrade='sudo zypper dup'
+alias clean-cache='sudo zypper clean'
+alias please='sudo'
+
+# configuration-settings
+alias ccli-help='less ~/.config/ccli/help.txt'
+alias ccli-settings='not installed'
+
+# Created by farhan sadik


### PR DESCRIPTION
# CCLI 
Alpha v0.1.1

## What's New  
 1 Added Configuration for `RedHat` and `Feadora` 
 2 Added Configuration for `openSUSE` 
 3 Added command `please` which will work instead of `sudo`
    example ~ `please install toilet` which is mean sudo apt-get install toilet 
 4 Added command `cache-clean` which will clean all of your cache 

## To-Do
 1 Please rename project `Common-command-line-interface-CCLI` to `CCLI`
 2 I didn't add support for **RedHat**, **Feadora** and **openSUSE**, even those are not tested. Just added those config files.
 3 If you want, then I can create a configuration for **android** also. But I already added **ccli** on my [EchoMinal Project](https://github.com/farhansadik/EchoMinal)

Farhan Sadik 
Square Development Group
